### PR TITLE
Update package installer

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -75,8 +75,8 @@ fn is_package_installed(package_name: &String) -> bool {
 }
 
 fn install_package(package: &String) -> Output {
-    Command::new("sudo")
-        .args(&vec!["yum", "install", "-y", package])
+    Command::new("yum")
+        .args(&vec!["install", "-y", package])
         .output()
         .unwrap()
 }


### PR DESCRIPTION
This PR updates the package installation process. It doesn't `panic` anymore when a package couldn't be installed.
It also requires root privileges now for package installation
