### PR TITLE
use os_type crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ authors = ["Jan Schulte <hello@unexpected-co.de>"]
 yaml-rust = "0.2.*"
 term = "0.2"
 rust-crypto = "0.2.31"
+os_type="0.1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::fs::File;
 use std::process;
 use std::env;
 use system_services::SystemInterface;
+extern crate os_type;
 mod configuration;
 mod provisioner;
 mod logger;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,4 +1,5 @@
-use system_services::{OSType};
+use os_type::OSType;
+// use system_services::{OSType};
 
 
 pub struct Platform {

--- a/src/platform_support.rs
+++ b/src/platform_support.rs
@@ -1,10 +1,11 @@
 use system_services;
+use os_type;
 use system_services::SystemInterface;
 
 pub fn is_supported() -> bool {
     let service = system_services::SystemServices;
     match service.os_type() {
-        system_services::OSType::Redhat => true,
+        os_type::OSType::Redhat => true,
         _ => false
     }
 }

--- a/src/system_services.rs
+++ b/src/system_services.rs
@@ -3,14 +3,10 @@ use std::fs;
 use std::io::prelude::*;
 use std::fs::File;
 use platform;
+extern crate os_type;
 
 #[derive(Clone)]
 pub struct SystemServices;
-
-pub enum OSType {
-    Redhat,
-    Unknown
-}
 
 pub trait SystemInterface {
     fn file_exists(&self, path: &String) -> bool;
@@ -19,7 +15,7 @@ pub trait SystemInterface {
     fn install_package(&self, package: &String) -> Output;
     fn get_hostname(&self) -> Option<String>;
     fn set_hostname(&self, new_hostname: &String) -> bool;
-    fn os_type(&self) -> OSType;
+    fn os_type(&self) -> os_type::OSType;
 }
 
 impl SystemInterface for SystemServices {
@@ -93,12 +89,7 @@ impl SystemInterface for SystemServices {
         output.status.success()
     }
 
-    fn os_type(&self) -> OSType {
-        if self.file_exists(&"/etc/redhat-release".to_string()) ||
-            self.file_exists(&"/etc/centos-release".to_string()){
-                OSType::Redhat
-            } else {
-                OSType::Unknown
-            }
+    fn os_type(&self) -> os_type::OSType {
+        os_type::current_platform()
     }
 }


### PR DESCRIPTION
This PR uses the https://github.com/schultyy/os_type crate to figure out which type the host operating system has.
